### PR TITLE
Specify numpy and h5py version numbers to be compatible with tf2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow==2.4
-numpy
+numpy==1.19.2
 scipy
 matplotlib
-h5py
+h5py==2.10.0


### PR DESCRIPTION
Installing the requirements in a fresh python 3.8 venv caused newer versions of h5py (3.2.1) and numpy (1.20.3) to be installed, and pip will throw an error that they are not compatible with tf 2.4.0